### PR TITLE
chore: add vscode i18n ally config

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "lokalise.i18n-ally"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+    "i18n-ally.sourceLanguage": "Chinese-English-0220",
+    "i18n-ally.displayLanguage": "chinese",
+    "i18n-ally.enabledFrameworks": [
+        "custom"
+    ],
+    "i18n-ally.localesPaths": [
+        "localizations"
+    ],
+    "i18n-ally.editor.preferEditor": true,
+    "i18n-ally.keystyle": "nested",
+    "i18n-ally.disablePathParsing": true
+
+}


### PR DESCRIPTION
添加了 vscode [i18n ally](https://github.com/lokalise/i18n-ally) 的配置可以更方便管理、检查翻译了

![demo](https://user-images.githubusercontent.com/18414281/222141805-f16468b1-24ff-4329-81cd-29f154dde8be.png)
